### PR TITLE
build:* and start:* need single quotes to work on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 	"scripts": {
 		"clean": "rimraf ./_site",
 		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean 'build:*'",
-		"build:webpack": "webpack",
+		"build:webpack": "NODE_OPTIONS=--openssl-legacy-provider webpack",
 		"build:eleventy": "eleventy",
 		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel 'start:*'",
-		"start:webpack": "webpack -w",
+		"start:webpack": "NODE_OPTIONS=--openssl-legacy-provider webpack -w",
 		"start:eleventy": "eleventy --serve",
 		"prettier": "prettier '{src/**/*.{js,css,json,html},*.js,*.json,*.html}'",
 		"stylelint": "stylelint 'src/css/**/*.css'",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
 	"license": "MIT",
 	"scripts": {
 		"clean": "rimraf ./_site",
-		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean build:*",
+		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean 'build:*'",
 		"build:webpack": "webpack",
 		"build:eleventy": "eleventy",
-		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel start:*",
+		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel 'start:*'",
 		"start:webpack": "webpack -w",
 		"start:eleventy": "eleventy --serve",
 		"prettier": "prettier '{src/**/*.{js,css,json,html},*.js,*.json,*.html}'",


### PR DESCRIPTION
When running 'yarn build' or 'yarn start' on macOS with Bash & Node v21.1.0, you get an error because * gets interpreted as a glob pattern. Surround the specs with ' to make it work.