### PR TITLE
Run webpack with NODE_OPTIONS=--openssl-legacy-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 	"scripts": {
 		"clean": "rimraf ./_site",
 		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean build:*",
-		"build:webpack": "webpack",
+		"build:webpack": "NODE_OPTIONS=--openssl-legacy-provider webpack",
 		"build:eleventy": "eleventy",
 		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel start:*",
-		"start:webpack": "webpack -w",
+		"start:webpack": "NODE_OPTIONS=--openssl-legacy-provider webpack -w",
 		"start:eleventy": "eleventy --serve",
 		"prettier": "prettier '{src/**/*.{js,css,json,html},*.js,*.json,*.html}'",
 		"stylelint": "stylelint 'src/css/**/*.css'",


### PR DESCRIPTION
Fixes `error:0308010C:digital envelope routines::unsupported)` when running webpack on Node>=17. Setting the environment variable `NODE_OPTIONS` to `--openssl-legacy-provider` allows webpack to run correctly.